### PR TITLE
Fix memory safety issues

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -1,0 +1,18 @@
+system=`uname`
+if [[ $system == "Linux" ]]; then
+    ext="so"
+elif [[ $system == "Darwin" ]]; then
+    ext="dylib"
+else
+    echo "Unsupported system: $system"
+    exit 1
+fi
+
+here=`cd $(dirname $BASH_SOURCE); pwd`
+
+export PROJECT_ROOT=`cd $here/..; pwd`
+export MODULE_DIR="$PROJECT_ROOT/target/debug"
+export MODULE_ORIGINAL=libtest_module.$ext
+export MODULE_RENAMED=test-module.so
+export EMACS=${EMACS:-emacs}
+export RUST_BACKTRACE=${RUST_BACKTRACE:-0}

--- a/bin/fn.sh
+++ b/bin/fn.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+here=`cd $(dirname $BASH_SOURCE); pwd`
+source $here/env.sh
+
+# test-module
+`cd $MODULE_DIR && ln -f -s $MODULE_ORIGINAL $MODULE_RENAMED`
+
+FN=$1
+MODULE="$MODULE_DIR/$MODULE_RENAMED"
+
+$EMACS -batch -l $MODULE -f $FN

--- a/bin/fn.sh
+++ b/bin/fn.sh
@@ -8,5 +8,6 @@ source $here/env.sh
 
 FN=$1
 MODULE="$MODULE_DIR/$MODULE_RENAMED"
+TEST="$PROJECT_ROOT/test-module/src/test.el"
 
-$EMACS -batch -l $MODULE -f $FN
+$EMACS -batch -l $MODULE -l $TEST -f $FN

--- a/bin/load.sh
+++ b/bin/load.sh
@@ -2,20 +2,11 @@
 
 # (Re)load test-module into a running Emacs instance.
 
-system=`uname`
-if [[ $system == "Linux" ]]; then
-    ext="so"
-elif [[ $system == "Darwin" ]]; then
-    ext="dylib"
-else
-    echo "Unsupported system: $system"
-    exit 1
-fi
-
 here=`cd $(dirname $BASH_SOURCE); pwd`
-root=`cd $here/..; pwd`
-RS_MODULE=$(find $root -iname "*emacs_rs_module*.$ext" | head -n 1)
-MODULE=$root/target/debug/libtest_module.$ext
+source $here/env.sh
+
+RS_MODULE=$(find $PROJECT_ROOT -iname "*emacs_rs_module*.$ext" | head -n 1)
+MODULE="$MODULE_DIR/$MODULE_ORIGINAL"
 
 read -r -d '' expr <<EOF
 (progn

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -2,32 +2,17 @@
 
 # FIX: Use Rust instead of bash to drive the tests.
 
-system=`uname`
-if [[ $system == "Linux" ]]; then
-    ext="so"
-elif [[ $system == "Darwin" ]]; then
-    ext="dylib"
-else
-    echo "Unsupported system: $system"
-    exit 1
-fi
-
 here=`cd $(dirname $BASH_SOURCE); pwd`
-root=`cd $here/..; pwd`
-MODULE_DIR=$root/target/debug
+source $here/env.sh
 
 # rs-module
 `cd $MODULE_DIR && ln -f -s libemacs_rs_module.$ext rs-module.so`
 
 # test-module
-MODULE_ORIGINAL=libtest_module.$ext
-MODULE_RENAMED=test-module.so
 `cd $MODULE_DIR && ln -f -s $MODULE_ORIGINAL $MODULE_RENAMED`
 
-EMACS=emacs
-
-RUST_BACKTRACE=0 $EMACS -batch -l ert \
-              -l $MODULE_DIR/$MODULE_RENAMED \
-              -l $MODULE_DIR/rs-module.so \
-              -l $root/test-module/src/test.el \
-              -f ert-run-tests-batch-and-exit
+$EMACS -batch -l ert \
+       -l "$MODULE_DIR/$MODULE_RENAMED" \
+       -l "$MODULE_DIR/rs-module.so" \
+       -l "$PROJECT_ROOT/test-module/src/test.el" \
+       -f ert-run-tests-batch-and-exit

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,10 @@ pub enum ErrorKind {
 
 pub type Result<T> = result::Result<T, Error>;
 
+// FIX: Make this into RootedValue (or ProtectedValue), and make it safe. XXX: The problem is that
+// the raw value will be leaked when RootedValue is dropped, since `free_global_ref` requires an env
+// (thus cannot be called there). This is likely a mis-design in Emacs (In Erlang,
+// `enif_keep_resource` and `enif_release_resource` don't require an env).
 impl TempValue {
     unsafe fn new(raw: emacs_value) -> Self {
         Self { raw }

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,9 +50,11 @@ impl TempValue {
 
     /// # Safety
     ///
-    /// This must only be temporarily used to inspect a non-local signal/throw from Lisp.
+    /// This must only be used with the [`Env`] from which the error originated.
+    ///
+    /// [`Env`]: struct.Env.html
     pub unsafe fn value<'e>(&self, env: &'e Env) -> Value<'e> {
-        Value::new(self.raw, env)
+        Value::new_protected(self.raw, env)
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -34,7 +34,8 @@ macro_rules! raw_call_value {
             // println!("raw_call_value {:?}", stringify!($name));
             let result: $crate::Result<$crate::raw::emacs_value> = raw_call!($env, $name $(, $args)*);
             result.map(|raw| unsafe {
-                $crate::Value::new(raw, $env)
+                // TODO: In some cases, we can get away without protection. Try optimizing them.
+                $crate::Value::new_protected(raw, $env)
             })
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -7,6 +7,7 @@ macro_rules! raw_fn {
 macro_rules! raw_call_no_exit {
     ($env:ident, $name:ident $(, $args:expr)*) => {
         unsafe {
+            // println!("raw_call_no_exit {:?}", stringify!($name));
             let $name = raw_fn!($env, $name);
             $name($env.raw $(, $args)*)
         }
@@ -16,6 +17,7 @@ macro_rules! raw_call_no_exit {
 macro_rules! raw_call {
     ($env:expr, $name:ident $(, $args:expr)*) => {
         {
+            // println!("raw_call {:?}", stringify!($name));
             let env = $env;
             let result = unsafe {
                 let $name = raw_fn!(env, $name);
@@ -29,6 +31,7 @@ macro_rules! raw_call {
 macro_rules! raw_call_value {
     ($env:ident, $name:ident $(, $args:expr)*) => {
         {
+            // println!("raw_call_value {:?}", stringify!($name));
             let result: $crate::Result<$crate::raw::emacs_value> = raw_call!($env, $name $(, $args)*);
             result.map(|raw| unsafe {
                 $crate::Value::new(raw, $env)
@@ -41,6 +44,7 @@ macro_rules! raw_call_value {
 macro_rules! call_lisp {
     ($env:ident, $name:expr $(, $arg:expr)*) => {
         {
+            // println!("call_lisp {:?}", $name);
             let symbol: $crate::Value = $env.intern($name)?;
             let args = &mut [$($arg.raw,)*];
             raw_call_value!($env, funcall, symbol.raw, args.len() as ::libc::ptrdiff_t, args.as_mut_ptr())

--- a/test-module/src/lib.rs
+++ b/test-module/src/lib.rs
@@ -12,6 +12,7 @@ mod macros;
 mod test_basics;
 mod test_error;
 mod test_transfer;
+mod test_lifetime;
 
 emacs_plugin_is_GPL_compatible!();
 emacs_module_init!(init);
@@ -27,6 +28,7 @@ fn init(env: &Env) -> Result<Value> {
     test_basics::init(env)?;
     test_error::init(env)?;
     test_transfer::init(env)?;
+    test_lifetime::init(env)?;
 
     env.provide(MODULE)
 }

--- a/test-module/src/macros.rs
+++ b/test-module/src/macros.rs
@@ -82,7 +82,7 @@ macro_rules! defuns {
                 let mut _iter = args.iter();
                 // XXX: .unwrap()
                 $(let $arg = unsafe {
-                    $crate::Value::new(*_iter.next().unwrap(), &env)
+                    $crate::Value::new_protected(*_iter.next().unwrap(), &env)
                 };)*
                 wrapped(&env $(, $arg)*)
             }

--- a/test-module/src/test.el
+++ b/test-module/src/test.el
@@ -1,4 +1,5 @@
 (require 't)
+(require 'subr-x)
 
 (ert-deftest convert::inc ()
   (should (= (t/inc 3) 4))
@@ -129,11 +130,32 @@
     (should (equal (t/hash-map:set m "a" "2") "1"))
     (should (equal (t/hash-map:get m "a") "2"))))
 
-(ert-deftest lifetime::gc-after-new-string ()
-  (t/gc-after-new-string))
+;;; Tests that, if failed, crash the whole process unrecoverably. They will be run under a
+;;; sub-process Emacs.
+(defmacro destructive-test (name)
+  `(ert-deftest ,(intern (format "destructive::%s" name)) ()
+     (let ((name ,(format "t/%s" name))
+           (exit-code)
+           (error-string)
+           (error-file (make-temp-file "destructive-fn")))
+       (setq exit-code (call-process
+                        (format "%s/%s" (getenv "PROJECT_ROOT") "bin/fn.sh")
+                        nil             ; no input
+                        (list (if (getenv "VERBOSE")
+                                  '(:file "/dev/stderr") ; ert prints stderr, not stdout.
+                                t)
+                              error-file)
+                        t
+                        name))
+       (setq error-string (with-temp-buffer
+                            (insert-file-contents error-file)
+                            (goto-char (point-max))
+                            (beginning-of-line 0)
+                            (string-trim-right
+                             (buffer-substring-no-properties (point) (point-max)))))
+       (unless (= exit-code 0)
+         (error "Exit code: %s. Error: %s" exit-code error-string)))))
 
-(ert-deftest lifetime::gc-after-uninterning ()
-  (t/gc-after-uninterning))
-
-(ert-deftest lifetime::gc-after-retrieving ()
-  (t/gc-after-retrieving))
+(destructive-test gc-after-new-string)
+(destructive-test gc-after-uninterning)
+(destructive-test gc-after-retrieving)

--- a/test-module/src/test.el
+++ b/test-module/src/test.el
@@ -1,11 +1,5 @@
 (require 't)
 
-(ert-deftest lifetime ()
-  (let ((h (t/use-after-gc)))
-    (message "Here")
-    (garbage-collect)
-    (print h)))
-
 (ert-deftest convert::inc ()
   (should (= (t/inc 3) 4))
   (should (equal (documentation 't/inc) "1+"))
@@ -134,3 +128,12 @@
 
     (should (equal (t/hash-map:set m "a" "2") "1"))
     (should (equal (t/hash-map:get m "a") "2"))))
+
+(ert-deftest lifetime::gc-after-new-string ()
+  (t/gc-after-new-string))
+
+(ert-deftest lifetime::gc-after-uninterning ()
+  (t/gc-after-uninterning))
+
+(ert-deftest lifetime::gc-after-retrieving ()
+  (t/gc-after-retrieving))

--- a/test-module/src/test.el
+++ b/test-module/src/test.el
@@ -159,3 +159,9 @@
 (destructive-test gc-after-new-string)
 (destructive-test gc-after-uninterning)
 (destructive-test gc-after-retrieving)
+
+;;; TODO: The way this test is called is a bit convoluted.
+(defun t/gc-after-catching ()
+  (t/gc-after-catching-1
+   (lambda () (error "abc"))))
+(destructive-test gc-after-catching)

--- a/test-module/src/test.el
+++ b/test-module/src/test.el
@@ -1,5 +1,11 @@
 (require 't)
 
+(ert-deftest lifetime ()
+  (let ((h (t/use-after-gc)))
+    (message "Here")
+    (garbage-collect)
+    (print h)))
+
 (ert-deftest convert::inc ()
   (should (= (t/inc 3) 4))
   (should (equal (documentation 't/inc) "1+"))

--- a/test-module/src/test_basics.rs
+++ b/test-module/src/test_basics.rs
@@ -98,6 +98,124 @@ fn to_lowercase_or_nil(env: &CallEnv) -> Result<Value> {
     r.into_lisp(env)
 }
 
+fn _use_after_gc(env: &CallEnv) -> Result<Value> {
+    let n = 2;
+    let h = env.call("make-hash-table", &[
+        env.intern(":test")?,
+        env.intern("equal")?,
+        env.intern(":size")?,
+        n.into_lisp(env)?
+    ])?;
+    let mut v = Vec::with_capacity(n as usize);
+    for _ in 0..n {
+        v.push("0123456789".into_lisp(env)?);
+        env.call("garbage-collect", &[])?;
+    }
+    env.call("puthash", &[
+        "0".into_lisp(env)?,
+        env.call("list", &v)?,
+        h,
+    ])?;
+
+    let l = env.call("list", &[h])?;
+
+    // for _ in 0..5 {
+    //     env.call("garbage-collect", &[])?;
+    // }
+
+    env.call("print", &[l])?;
+    Ok(l)
+}
+
+fn use_after_gc(env: &CallEnv) -> Result<Value> {
+    let n = 2;
+    let mut v = Vec::with_capacity(n as usize);
+
+    // // Crashes
+    // for _ in 0..n {
+    //     v.push("0".into_lisp(env)?);
+    //     env.call("garbage-collect", &[])?;
+    // }
+
+    // // Crashes
+    // let mut i = 0;
+    // while i < n {
+    //     i = i + 1;
+    //     v.push("0".into_lisp(env)?);
+    //     env.call("garbage-collect", &[])?;
+    // }
+
+    // // Crashes
+    // (|| {
+    //     v.push("0".into_lisp(env).unwrap());
+    // })();
+    // (|| {
+    //     v.push("0".into_lisp(env).unwrap());
+    // })();
+    // env.call("garbage-collect", &[])?;
+
+    // // Doesn't crash
+    // (|| {
+    //     v.push("0".into_lisp(env).unwrap());
+    //     v.push("0".into_lisp(env).unwrap());
+    // })();
+    // env.call("garbage-collect", &[]);
+
+    // // Doesn't crashes
+    // v.push("0".into_lisp(env).unwrap());
+    // (|| {
+    //     v.push("0".into_lisp(env).unwrap());
+    // })();
+    // env.call("garbage-collect", &[]);
+
+    // // Crashes
+    // v.push("0".into_lisp(env).unwrap());
+    // (|| {
+    //     v.push("0".into_lisp(env).unwrap());
+    // })();
+    // v.push("0".into_lisp(env)?);
+    // env.call("garbage-collect", &[])?;
+
+    // Crashes
+    (|| {
+        v.push("0".into_lisp(env).unwrap());
+    })();
+    "0".into_lisp(env)?;
+    // env.message("0")?; // Also crashes
+    env.call("garbage-collect", &[])?;
+
+    // // Doesn't crash (? -> .unwrap())
+    // (|| {
+    //     v.push("0".into_lisp(env).unwrap());
+    // })();
+    // "0".into_lisp(env).unwrap();
+    // env.call("garbage-collect", &[])?;
+
+    // // Doesn't crash
+    // {
+    //     v.push("0".into_lisp(env)?);
+    //     env.call("garbage-collect", &[])?;
+    // }
+    // {
+    //     v.push("0".into_lisp(env)?);
+    //     env.call("garbage-collect", &[])?;
+    // }
+
+    // // Doesn't crash
+    // let x = "0".into_lisp(env)?;
+    // for _ in 0..n {
+    //     v.push(x);
+    //     env.call("garbage-collect", &[])?;
+    // }
+
+    println!("v={:?}", v);
+    let l = env.call("list", &v)?;
+    println!("1");
+    env.call("print", &[l])?;
+    println!("2");
+    Ok(l)
+}
+
 pub fn init(env: &Env) -> Result<()> {
     using_fset(env)?;
     using_defuns(env)?;
@@ -112,6 +230,7 @@ pub fn init(env: &Env) -> Result<()> {
         env, *MODULE_PREFIX, {
             "sum" => (sum, 2..2),
             "to-lowercase-or-nil" => (to_lowercase_or_nil, 1..1),
+            "use-after-gc" => (use_after_gc, 0..0),
         }
     }
 

--- a/test-module/src/test_basics.rs
+++ b/test-module/src/test_basics.rs
@@ -98,124 +98,6 @@ fn to_lowercase_or_nil(env: &CallEnv) -> Result<Value> {
     r.into_lisp(env)
 }
 
-fn _use_after_gc(env: &CallEnv) -> Result<Value> {
-    let n = 2;
-    let h = env.call("make-hash-table", &[
-        env.intern(":test")?,
-        env.intern("equal")?,
-        env.intern(":size")?,
-        n.into_lisp(env)?
-    ])?;
-    let mut v = Vec::with_capacity(n as usize);
-    for _ in 0..n {
-        v.push("0123456789".into_lisp(env)?);
-        env.call("garbage-collect", &[])?;
-    }
-    env.call("puthash", &[
-        "0".into_lisp(env)?,
-        env.call("list", &v)?,
-        h,
-    ])?;
-
-    let l = env.call("list", &[h])?;
-
-    // for _ in 0..5 {
-    //     env.call("garbage-collect", &[])?;
-    // }
-
-    env.call("print", &[l])?;
-    Ok(l)
-}
-
-fn use_after_gc(env: &CallEnv) -> Result<Value> {
-    let n = 2;
-    let mut v = Vec::with_capacity(n as usize);
-
-    // // Crashes
-    // for _ in 0..n {
-    //     v.push("0".into_lisp(env)?);
-    //     env.call("garbage-collect", &[])?;
-    // }
-
-    // // Crashes
-    // let mut i = 0;
-    // while i < n {
-    //     i = i + 1;
-    //     v.push("0".into_lisp(env)?);
-    //     env.call("garbage-collect", &[])?;
-    // }
-
-    // // Crashes
-    // (|| {
-    //     v.push("0".into_lisp(env).unwrap());
-    // })();
-    // (|| {
-    //     v.push("0".into_lisp(env).unwrap());
-    // })();
-    // env.call("garbage-collect", &[])?;
-
-    // // Doesn't crash
-    // (|| {
-    //     v.push("0".into_lisp(env).unwrap());
-    //     v.push("0".into_lisp(env).unwrap());
-    // })();
-    // env.call("garbage-collect", &[]);
-
-    // // Doesn't crashes
-    // v.push("0".into_lisp(env).unwrap());
-    // (|| {
-    //     v.push("0".into_lisp(env).unwrap());
-    // })();
-    // env.call("garbage-collect", &[]);
-
-    // // Crashes
-    // v.push("0".into_lisp(env).unwrap());
-    // (|| {
-    //     v.push("0".into_lisp(env).unwrap());
-    // })();
-    // v.push("0".into_lisp(env)?);
-    // env.call("garbage-collect", &[])?;
-
-    // Crashes
-    (|| {
-        v.push("0".into_lisp(env).unwrap());
-    })();
-    "0".into_lisp(env)?;
-    // env.message("0")?; // Also crashes
-    env.call("garbage-collect", &[])?;
-
-    // // Doesn't crash (? -> .unwrap())
-    // (|| {
-    //     v.push("0".into_lisp(env).unwrap());
-    // })();
-    // "0".into_lisp(env).unwrap();
-    // env.call("garbage-collect", &[])?;
-
-    // // Doesn't crash
-    // {
-    //     v.push("0".into_lisp(env)?);
-    //     env.call("garbage-collect", &[])?;
-    // }
-    // {
-    //     v.push("0".into_lisp(env)?);
-    //     env.call("garbage-collect", &[])?;
-    // }
-
-    // // Doesn't crash
-    // let x = "0".into_lisp(env)?;
-    // for _ in 0..n {
-    //     v.push(x);
-    //     env.call("garbage-collect", &[])?;
-    // }
-
-    println!("v={:?}", v);
-    let l = env.call("list", &v)?;
-    println!("1");
-    env.call("print", &[l])?;
-    println!("2");
-    Ok(l)
-}
-
 pub fn init(env: &Env) -> Result<()> {
     using_fset(env)?;
     using_defuns(env)?;
@@ -230,7 +112,6 @@ pub fn init(env: &Env) -> Result<()> {
         env, *MODULE_PREFIX, {
             "sum" => (sum, 2..2),
             "to-lowercase-or-nil" => (to_lowercase_or_nil, 1..1),
-            "use-after-gc" => (use_after_gc, 0..0),
         }
     }
 

--- a/test-module/src/test_lifetime.rs
+++ b/test-module/src/test_lifetime.rs
@@ -44,14 +44,18 @@ fn create_collect_use<'e, CF, UF>(
     Ok(v[0])
 }
 
-// macOS: Segmentation fault
+// Before fixing:
+// - macOS: Segmentation fault
+// - Linux: Segmentation fault
 fn gc_after_new_string(env: &CallEnv) -> Result<Value> {
     create_collect_use(env, 2, || {
         "0".into_lisp(env)
     }, print)
 }
 
-// macOS: Segmentation fault
+// Before fixing:
+// - macOS: Segmentation fault
+// - Linux: Segmentation fault
 fn gc_after_uninterning(env: &CallEnv) -> Result<Value> {
     // Wouldn't fail if count is 1 or 2.
     create_collect_use(env, 3, || {
@@ -61,7 +65,9 @@ fn gc_after_uninterning(env: &CallEnv) -> Result<Value> {
     }, print)
 }
 
-// macOS: Abort trap (since the violation happens in Rust)
+// Before fixing:
+// - macOS: Abort trap (since the violation happens in Rust)
+// - Linux: wrong-type-argument (maybe the runtime is a bit different in Linux?)
 fn gc_after_retrieving(env: &CallEnv) -> Result<Value> {
     create_collect_use(env, 2, || {
         // XXX: These come from `test_transfer` module.

--- a/test-module/src/test_lifetime.rs
+++ b/test-module/src/test_lifetime.rs
@@ -1,0 +1,79 @@
+use emacs::{Env, CallEnv, Value, IntoLisp, Result};
+
+use super::MODULE_PREFIX;
+
+fn gc(env: &CallEnv) -> Result<Value> {
+    env.call("garbage-collect", &[])
+}
+
+fn print<'e>(env: &'e CallEnv, v: Value) -> Result<Value<'e>> {
+    env.call("print", &[v])
+}
+
+fn create_collect_use<'e, CF, UF>(
+    env: &'e CallEnv,
+    count: usize,
+    creating: CF,
+    using: UF,
+) -> Result<Value>
+    where CF: Fn() -> Result<Value<'e>>,
+          UF: Fn(&'e CallEnv, Value) -> Result<Value<'e>>,
+{
+    let mut v = Vec::with_capacity(count);
+    for _ in 0..count {
+        let x = creating()?;
+        v.push(x);
+    }
+
+    gc(env)?;
+    let l = env.list(&v)?;
+    // Seems like the last value is not GC'ed, so loop backward.
+    for i in (0..count).rev() {
+        println!("using {}", i);
+        using(env, v[i])?;
+    }
+    Ok(l)
+}
+
+// macOS: Segmentation fault
+fn gc_after_new_string(env: &CallEnv) -> Result<Value> {
+    creating_gc_listing_using(env, 2, || {
+        "0".into_lisp(env)
+    }, print)
+}
+
+// macOS: Segmentation fault
+fn gc_after_uninterning(env: &CallEnv) -> Result<Value> {
+    creating_gc_listing_using(env, 2, || {
+        let x = env.intern("xyz")?;
+        env.call("unintern", &[x])?;
+        Ok(x)
+    }, print)
+}
+
+// macOS: Abort trap (since the violation happens in Rust)
+fn gc_after_retrieving(env: &CallEnv) -> Result<Value> {
+    creating_gc_listing_using(env, 2, || {
+        // XXX: These come from `test_transfer` module.
+        env.call(&format!("{}hash-map:make", *MODULE_PREFIX), &[])
+    }, |env, v| {
+        print(env, v)?; // Used: #<user-ptr ptr=... finalizer=...>. Free: #<misc free cell>.
+        env.call(&format!("{}hash-map:set", *MODULE_PREFIX), &[
+            v,
+            "x".into_lisp(env)?,
+            "y".into_lisp(env)?,
+        ])
+    })
+}
+
+pub fn init(env: &Env) -> Result<()> {
+    emacs_export_functions! {
+        env, *MODULE_PREFIX, {
+            "gc-after-new-string" => (gc_after_new_string, 0..0),
+            "gc-after-uninterning" => (gc_after_uninterning, 0..0),
+            "gc-after-retrieving" => (gc_after_retrieving, 0..0),
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #2 and related memory-safety issues.

Emacs runtime doesn't protect new values obtained from an env (module-allocated, or signaled/thrown).

This is a workaround for that.