### PR TITLE
Fix building on `aarch64-apple-darwin`

### DIFF
--- a/emacs-module/Cargo.toml
+++ b/emacs-module/Cargo.toml
@@ -13,4 +13,4 @@ license = "BSD-3-Clause"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.51.1"
+bindgen = "0.56.0"


### PR DESCRIPTION
Update `bindgen` dependency to fix builds on Apple Silicon. Building
with the dependency on v0.51.10 results in the following error:

```
error: failed to run custom build command for `emacs_module v0.12.0 (/Users/nwjsmith/Code/nwjsmith/emacs-module-rs/emacs-module)`

Caused by:
  process didn't exit successfully: `/Users/nwjsmith/Code/nwjsmith/emacs-module-rs/target/debug/build/emacs_module-8570cc387771c210/build-script-build` (exit code: 101)
  --- stderr
  thread 'main' panicked at 'libclang error; possible causes include:
  - Invalid flag syntax
  - Unrecognized flags
  - Invalid flag arguments
  - File I/O errors
  If you encounter an error missing from this list, please file an issue or a PR!', /Users/nwjsmith/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.51.1/src/ir/context.rs:571:15
  stack backtrace:
     0:        0x10080cc9c - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h5b35424d98a84d2e
     1:        0x100837118 - core::fmt::write::h66f440bd230d5049
     2:        0x100806dfc - std::io::Write::write_fmt::h5f96133b528343e9
     3:        0x10081af20 - std::panicking::default_hook::{{closure}}::h30a27193d23180ec
     4:        0x10081ac74 - std::panicking::default_hook::h200a4c4ea2ec4037
     5:        0x10081b3d4 - std::panicking::rust_panic_with_hook::hf19f16435a47814d
     6:        0x10080d158 - std::panicking::begin_panic_handler::{{closure}}::h7d30afed417a766c
     7:        0x10080cddc - std::sys_common::backtrace::__rust_end_short_backtrace::hafb39ae92d7ecfa2
     8:        0x10081b010 - _rust_begin_unwind
     9:        0x10083d558 - core::panicking::panic_fmt::h266736c2dfe1041a
    10:        0x10083d134 - core::option::expect_failed::h08b745f41456567e
    11:        0x1004e12b0 - core::option::Option<T>::expect::h1157b4f5b8072ec9
                                 at /private/tmp/rust-20210109-48369-1kpc7mp/rustc-1.49.0-src/library/core/src/option.rs:349:21
    12:        0x1003caf30 - bindgen::ir::context::BindgenContext::new::h2ef3179d94dd4352
                                 at /Users/nwjsmith/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.51.1/src/ir/context.rs:565:13
    13:        0x1004fcecc - bindgen::Bindings::generate::h8214788ebb871a74
                                 at /Users/nwjsmith/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.51.1/src/lib.rs:1875:27
    14:        0x1004fb2e4 - bindgen::Builder::generate::h95bebcc84303c1f1
                                 at /Users/nwjsmith/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.51.1/src/lib.rs:1244:9
    15:        0x10037a97c - build_script_build::main::h285cef4aaeef9605
                                 at /Users/nwjsmith/Code/nwjsmith/emacs-module-rs/emacs-module/build.rs:8:5
    16:        0x10037ab2c - core::ops::function::FnOnce::call_once::hbc0f26065fe28ad1
                                 at /private/tmp/rust-20210109-48369-1kpc7mp/rustc-1.49.0-src/library/core/src/ops/function.rs:227:5
    17:        0x100377f9c - std::sys_common::backtrace::__rust_begin_short_backtrace::h2c420e7da5759ded
                                 at /private/tmp/rust-20210109-48369-1kpc7mp/rustc-1.49.0-src/library/std/src/sys_common/backtrace.rs:125:18
    18:        0x100378b28 - std::rt::lang_start::{{closure}}::he2aa78bd823e3378
                                 at /private/tmp/rust-20210109-48369-1kpc7mp/rustc-1.49.0-src/library/std/src/rt.rs:66:18
    19:        0x10081f804 - std::rt::lang_start_internal::h5a4531374b5aaa0d
    20:        0x100378b00 - std::rt::lang_start::hf815aedcecb975b4
                                 at /private/tmp/rust-20210109-48369-1kpc7mp/rustc-1.49.0-src/library/std/src/rt.rs:65:5
    21:        0x10037aaac - _main
```

Updating `bindgen` to any version > v0.55.0 fixes the issue.