### PR TITLE
Add `CHANGELOG` entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+- Fixed compilation on `aarch64-apple-darwin` (Apple Silicon).
 
 ## [0.16.0] - 2021-01-31
 - Replaced `failure` with `anyhow` and `thiserror`. Re-export `anyhow` as `emacs::error::anyhow`.


### PR DESCRIPTION
Add an entry for the unreleased fix for `aarch64-apple-darwin`.

Sorry, I forgot to add this in the original pull request (#38)