### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "emacs"
 version = "0.19.0"
 edition = "2021"
 description = "Rust library for creating Emacs's dynamic modules"
-homepage = "https://github.com/ubolonton/emacs-module-rs"
+repository = "https://github.com/ubolonton/emacs-module-rs"
 documentation = "https://ubolonton.github.io/emacs-module-rs/"
 authors = [
     "Aaron France <aaron.l.france@gmail.com>",


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.